### PR TITLE
add ament_cmake_ros to ros_core

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -16,6 +16,9 @@
   <exec_depend>ament_cmake_gmock</exec_depend>
   <exec_depend>ament_cmake_pytest</exec_depend>
 
+  <!-- ament_cmake_ros repo -->
+  <exec_depend>ament_cmake_ros</exec_depend>
+
   <!-- ament_index repo -->
   <exec_depend>ament_index_cpp</exec_depend>
   <exec_depend>ament_index_python</exec_depend>


### PR DESCRIPTION
several packages in ros_core rely on ament_cmake_ros as well as the packages generated by `ros2 pkg create` so I figured it makes sense to include this package in `ros_core` as well