### PR TITLE
Include sros2 as a exec_depend ros-core

### DIFF
--- a/desktop/package.xml
+++ b/desktop/package.xml
@@ -54,8 +54,6 @@
   <exec_depend>examples_rclpy_minimal_service</exec_depend>
   <exec_depend>examples_rclpy_minimal_subscriber</exec_depend>
 
-  <!-- sros2 repo -->
-  <exec_depend>sros2</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -59,6 +59,7 @@
   <exec_depend>ros2service</exec_depend>
   <exec_depend>ros2srv</exec_depend>
   <exec_depend>ros2topic</exec_depend>
+  <exec_depend>sros2</exec_depend>
 
   <!-- class_loader repo -->
   <exec_depend>class_loader</exec_depend>


### PR DESCRIPTION
Facilitate default security by including sros2 in the CLI provided through ros-core, or at very least `ros-base`. Having sros CLI shipped with crystal core packages would helpful when using the official docker images derived from the `ros-core` and `ros-base` variants with security.

Ping @tfoote @nuclearsandwich  or @sloretz .