### PR TITLE
Added missing dependency for ros2actions package for ros2cli

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -48,6 +48,7 @@
   <exec_depend>common_interfaces</exec_depend>
 
   <!-- ros2cli repo -->
+  <exec_depend>ros2action</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2lifecycle</exec_depend>
   <exec_depend>ros2msg</exec_depend>


### PR DESCRIPTION
Dashing introduced actions and a nice CLI package for interacting with them. The default install does not include the cli actions package, it has to be installed separately. This PR adds ros2actions as a dependency to core so it will be installed along with the other CLI packages.