### PR TITLE
add rqt_common_plugins to desktop

### DIFF
--- a/desktop/package.xml
+++ b/desktop/package.xml
@@ -62,6 +62,9 @@
   <exec_depend>examples_rclpy_minimal_service</exec_depend>
   <exec_depend>examples_rclpy_minimal_subscriber</exec_depend>
 
+  <!-- rqt metapackages -->
+  <exec_depend>rqt_common_plugins</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Draft PR in case https://github.com/ros-visualization/rqt_common_plugins/pull/457 gets merged and released.
Otherwise it should be updated to list all the rqt plugins explicitly

A new variants rep will be needed once this is targeted at a specific distro

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>