### PR TITLE
use geometry2 metapackage in ros_base

### DIFF
--- a/ros_base/package.xml
+++ b/ros_base/package.xml
@@ -12,12 +12,7 @@
   <exec_depend>ros_core</exec_depend>
 
   <!-- geometry2 repo -->
-  <!-- TODO(clalancette) switch to using geometry2 metapackage -->
-  <exec_depend>tf2</exec_depend>
-  <exec_depend>tf2_eigen</exec_depend>
-  <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>tf2_kdl</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>geometry2</exec_depend>
 
   <!-- kdl_parser repo -->
   <exec_depend>kdl_parser</exec_depend>


### PR DESCRIPTION
this adds the missing `tf2_sensor_msgs` package and allows for other geometry2 packages to be ported without having to modify the variants. This change does not require a change to the REP

Requires https://github.com/ros2/geometry2/pull/184 to be released before merging

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>