### PR TITLE
Add ros2interface to ros_core variant

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -50,6 +50,7 @@
   <!-- ros2cli repo -->
   <exec_depend>ros2action</exec_depend>
   <exec_depend>ros2component</exec_depend>
+  <exec_depend>ros2interface</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2lifecycle</exec_depend>
   <exec_depend>ros2msg</exec_depend>


### PR DESCRIPTION
`ros2 interface` is mentioned in the action tutorial https://index.ros.org/doc/ros2/Tutorials/Actions/Creating-an-Action/ , but does not come installed with `ros-eloquent-desktop`.