### PR TITLE
Add ros2doctor to ros_core variant

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -50,6 +50,7 @@
   <!-- ros2cli repo -->
   <exec_depend>ros2action</exec_depend>
   <exec_depend>ros2component</exec_depend>
+  <exec_depend>ros2doctor</exec_depend>
   <exec_depend>ros2interface</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2lifecycle</exec_depend>


### PR DESCRIPTION
So it gets installed when someone installs `ros-eloquent-ros-core`