### PR TITLE
Add rosbag2 to ros variants

### DIFF
--- a/ros_base/package.xml
+++ b/ros_base/package.xml
@@ -11,6 +11,9 @@
 
   <exec_depend>ros_core</exec_depend>
 
+  <!-- rosbag2 repo -->
+  <exec_depend>rosbag2</exec_depend>
+  
   <!-- geometry2 repo -->
   <exec_depend>geometry2</exec_depend>
 


### PR DESCRIPTION
I wasn't sure whether it best belongs to `ros_core`, but ultimately settled on `ros_base`.