### PR TITLE
Add launch and launch_ros repos to ros_core variant

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -47,12 +47,23 @@
   <!-- common_interfaces repo -->
   <exec_depend>common_interfaces</exec_depend>
 
+  <!-- launch repo -->
+  <exec_depend>launch<exec_depend>
+  <exec_depend>launch_testing</exec_depend>
+  <exec_depend>launch_testing_amend_cmake</exec_depend>
+  <exec_depend>launch_xml</exec_depend>
+  <exec_depend>launch_yaml</exec_depend>
+
+  <!-- launch_ros repo -->
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>launch_testing_ros</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
+
   <!-- ros2cli repo -->
   <exec_depend>ros2action</exec_depend>
   <exec_depend>ros2component</exec_depend>
   <exec_depend>ros2doctor</exec_depend>
   <exec_depend>ros2interface</exec_depend>
-  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2lifecycle</exec_depend>
   <exec_depend>ros2multicast</exec_depend>
   <exec_depend>ros2node</exec_depend>

--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -50,7 +50,7 @@
   <!-- launch repo -->
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_testing</exec_depend>
-  <exec_depend>launch_testing_amend_cmake</exec_depend>
+  <exec_depend>launch_testing_ament_cmake</exec_depend>
   <exec_depend>launch_xml</exec_depend>
   <exec_depend>launch_yaml</exec_depend>
 

--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -48,7 +48,7 @@
   <exec_depend>common_interfaces</exec_depend>
 
   <!-- launch repo -->
-  <exec_depend>launch<exec_depend>
+  <exec_depend>launch</exec_depend>
   <exec_depend>launch_testing</exec_depend>
   <exec_depend>launch_testing_amend_cmake</exec_depend>
   <exec_depend>launch_xml</exec_depend>


### PR DESCRIPTION
Many, but not all, of these packages were transitively depended on before.
This ensures that all of them are included in an installation of ros_core.

Fixes #26