### PR TITLE
Replace ros2cli repo by ros2cli_common_extensions

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -59,8 +59,8 @@
   <exec_depend>launch_testing_ros</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   
-  <!-- ros2_common_extensions repo -->
-  <exec_depend>ros2_common_extensions</exec_depend>
+  <!-- ros2cli_common_extensions repo -->
+  <exec_depend>ros2cli_common_extensions</exec_depend>
 
   <!-- sros2 repo -->
   <exec_depend>sros2</exec_depend>

--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -58,20 +58,9 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch_testing_ros</exec_depend>
   <exec_depend>ros2launch</exec_depend>
-
-  <!-- ros2cli repo -->
-  <exec_depend>ros2action</exec_depend>
-  <exec_depend>ros2component</exec_depend>
-  <exec_depend>ros2doctor</exec_depend>
-  <exec_depend>ros2interface</exec_depend>
-  <exec_depend>ros2lifecycle</exec_depend>
-  <exec_depend>ros2multicast</exec_depend>
-  <exec_depend>ros2node</exec_depend>
-  <exec_depend>ros2param</exec_depend>
-  <exec_depend>ros2pkg</exec_depend>
-  <exec_depend>ros2run</exec_depend>
-  <exec_depend>ros2service</exec_depend>
-  <exec_depend>ros2topic</exec_depend>
+  
+  <!-- ros2_common_extensions repo -->
+  <exec_depend>ros2_common_extensions</exec_depend>
 
   <!-- sros2 repo -->
   <exec_depend>sros2</exec_depend>


### PR DESCRIPTION
That will also add argcomplete as a dependency https://github.com/ros2/ros2cli_common_extensions/pull/3/