### PR TITLE
add rclcpp_action to core

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -32,6 +32,7 @@
 
   <!-- rclcpp repo -->
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
 
   <!-- rclpy repo -->


### PR DESCRIPTION
Adds the missing `rclcpp_action` package to the `core` variant.

Closes #35.

