### PR TITLE
Use single quotes

### DIFF
--- a/desktop_full/package.xml
+++ b/desktop_full/package.xml
@@ -3,7 +3,7 @@
 <package format="2">
   <name>desktop_full</name>
   <version>0.10.0</version>
-  <description>Provides a "batteries included" experience to novice users.</description>
+  <description>Provides a 'batteries included' experience to novice users.</description>
 
   <maintainer email="geoff@openrobotics.org">Geoffrey Biggs</maintainer>
 


### PR DESCRIPTION
I hope to start contributing more from now on, so let's start by some low hanging fruit...

Use single quotes instead of double quotes so the description message of the debian package is displayed properly ('batteries included' instead of \&quot;batteries included\&quot;)

This should solve https://github.com/ros2/variants/issues/39