### PR TITLE
Rename ros_ign to ros_gz

### DIFF
--- a/desktop_full/package.xml
+++ b/desktop_full/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>desktop</exec_depend>
   <exec_depend>perception</exec_depend>
   <exec_depend>simulation</exec_depend>
-  <exec_depend>ros_ign_gazebo_demos</exec_depend>
+  <exec_depend>ros_gz_sim_demos</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/simulation/package.xml
+++ b/simulation/package.xml
@@ -14,10 +14,10 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>ros_base</exec_depend>
-  <exec_depend>ros_ign_bridge</exec_depend>
-  <exec_depend>ros_ign_gazebo</exec_depend>
-  <exec_depend>ros_ign_image</exec_depend>
-  <exec_depend>ros_ign_interfaces</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <exec_depend>ros_gz_image</exec_depend>
+  <exec_depend>ros_gz_interfaces</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Replacing #42 
`ros_ign` packages have been renamed to `ros_gz`. The packages are available in `humble` and `iron`, but have not yet been released into `rolling` on Noble.