### PR TITLE
Add dependency on ros2plugin in package.xml

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -75,6 +75,7 @@
   <exec_depend>class_loader</exec_depend>
   <!-- pluginlib repo -->
   <exec_depend>pluginlib</exec_depend>
+  <exec_depend>ros2plugin</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Description

Hi, `ros2plugin` was added to the pluginlib repo on last rolling sync, https://github.com/ros/pluginlib/blob/rolling/ros2plugin/CHANGELOG.rst. Without this package, we are unable to use `ros2 plugin` related commands, so I have added it in the `package.xml`

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
